### PR TITLE
added unclosed.md for additional test coverage and updated regex

### DIFF
--- a/bin/verify-links.sh
+++ b/bin/verify-links.sh
@@ -62,7 +62,7 @@ for file in ${mdFiles}; do
 
   # This sed will extract the href portion of the [..](..) - meaning
   # the stuff in the parens.
-  sed "s/.*\(\[[^\[\]*\]]([^()]*)\)/\1/" < ${tmp}1 > ${tmp}2  || continue
+  sed "s/.*\[*\]\([^()]*\)/\1/" < ${tmp}1 > ${tmp}2  || continue
 
   # Extract all headings/anchors.
   # And strip off the leading #'s and leading/trailing blanks

--- a/test/files.base
+++ b/test/files.base
@@ -10,3 +10,4 @@ Verifying: test/files/split2.md
 test/files/split2.md: Can't find: test/files/badlink5.md
 Verifying: test/files/split3.md
 Verifying: test/files/split.md
+Verifying: test/files/unclosed.md

--- a/test/files/unclosed.md
+++ b/test/files/unclosed.md
@@ -1,0 +1,4 @@
+###
+This is a page with an unclosed ( and an unclosed [
+[Kubernetes home page](https://kubernetes.io/).
+


### PR DESCRIPTION
md files that had unclosed parenthesis were causing false positives. I created a test file that reproduced the failure and then updated the regex responsible for extracting the href so that all tests are currently passing. 